### PR TITLE
Add Attachment Support to Discord feed

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -20,7 +20,7 @@ client.on("messageCreate", async (message) => {
         const channel = message.channel,
             guild = channel.guild,
             everyone = guild.roles.everyone;
-        
+
         if (!channel.permissionsFor(everyone).has(PermissionsBitField.Flags.ViewChannel))
             return;
 
@@ -32,9 +32,19 @@ client.on("messageCreate", async (message) => {
         await sql_client.connect();
 
         let authorData = (await message.guild.members.fetch(message.author.id))
+
+        let attachmentIds = null;
+        message.attachments.forEach(async attachments => {
+            if (attachmentIds == null) {
+                attachmentIds = [];
+            }
+            attachmentIds.push(attachments.id)
+        })
+
         sql_client.query({
-            // Note: All of these are apparently VARCHAR, except the last one is a BIGINT
-            text: `insert into messages (authorName, authorImage, content, channel, time, uuid, guildid) VALUES ($1, $2, $3, $4, $5, $6, $7);`,
+            // Schema: VARCHAR(255), VARCHAR(255), VARCHAR(4000), VARCHAR(255), VARCHAR(255), VARCHAR(255), BIGINT, VARCHAR(255), VARCHAR(4000)
+            // ALTER TABLE messages ADD COLUMN attachments VARCHAR(4000);
+            text: `insert into messages (authorName, authorImage, content, channel, time, uuid, guildid, userid, attachments) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);`,
             values: [
                 authorData.nickname ?? authorData.user.globalName ?? authorData.user.username,
                 message.author.displayAvatarURL(),
@@ -47,9 +57,10 @@ client.on("messageCreate", async (message) => {
                 }),
                 message.id,
                 message.guildId ?? null,
+                attachmentIds,
             ],
         }).then(() => {
-        }).catch(() => {});
+        }).catch(() => { });
 
         // Add Users to list
         if (message.mentions.users.size) {
@@ -73,7 +84,7 @@ client.on("messageCreate", async (message) => {
                     ],
                 }).then(() => {
                     sql_user_client.end();
-                }).catch(() => {});
+                }).catch(() => { });
             });
         }
 
@@ -99,7 +110,7 @@ client.on("messageCreate", async (message) => {
                     ],
                 }).then(() => {
                     sql_role_client.end();
-                }).catch(() => {});
+                }).catch(() => { });
             });
         }
 
@@ -126,9 +137,38 @@ client.on("messageCreate", async (message) => {
                     ],
                 }).then(() => {
                     sql_channel_client.end();
-                }).catch(() => {});
+                }).catch(() => { });
             });
         }
+
+        // Check if the message has any attachments
+        if (message.attachments.size) {
+            message.attachments.forEach(async attachments => {
+
+                const sql_attachment_client = await createClient({
+                    connectionString:
+                        process.env.VERCEL_PGSQL,
+                });
+
+                await sql_attachment_client.connect();
+                // Add attachments to list
+                sql_attachment_client.query({
+                    // Note: BIGINT, VARCHAR(1000), VARCHAR(255) <= Your schema
+                    // CREATE TABLE attachments(id BIGINT, name VARCHAR(255), link VARCHAR(1000), type VARCHAR(255));
+                    // ALTER TABLE CHANNELS ADD PRIMARY KEY (id);
+                    text: `insert into attachments (id, link, type, name) VALUES ($1, $2, $3, $4) ON CONFLICT (id) DO UPDATE SET id = $1, link = $2, type = $3, name = $4;`,
+                    values: [
+                        attachments.id,
+                        attachments.proxyURL,
+                        attachments.contentType,
+                        attachments.name
+                    ],
+                }).then(() => {
+                    sql_attachment_client.end();
+                }).catch((e) => { console.log(e) });
+            });
+        }
+
 
     } catch (e) { }
     //await sql`delete from messages where ctid in (select ctid from messages order by time limit 1)`

--- a/src/components/DiscordFeed/discordfeed.tsx
+++ b/src/components/DiscordFeed/discordfeed.tsx
@@ -271,7 +271,7 @@ export const GenerateMessageHTML: FC<{
                 // Unfortunatly that disqualifies most of the Discord GIF selector.
                 if (value.content.includes("https://tenor.com/view")) {
                     return (
-                        <span>
+                        <span key={index}>
                             <PaperClipOutlined />
                             <> </>
                             <a className={`text-sky-500 `}>Tenor-GIF</a>
@@ -281,7 +281,7 @@ export const GenerateMessageHTML: FC<{
 
                 if (/\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(value.content.replace(/\?.*/, ''))) {
                     return (
-                        <span>
+                        <span key={index}>
                             <CameraOutlined />
                             <a className={`text-sky-500 px-[4px]`}>{value.content.replace(/[^/]*\/\/(?:[^@]*@)?([^:/]+(?:\.[^:/]+)*).*/, '$1')}</a>
                             <br />
@@ -295,7 +295,7 @@ export const GenerateMessageHTML: FC<{
                     )
                 }
 
-                return <a className={`text-sky-500 `}>{content}</a>;
+                return <a key={index} className={`text-sky-500 `}>{content}</a>;
             })
 
             return <a>{content}</a>;      

--- a/src/components/DiscordFeed/discordfeed.tsx
+++ b/src/components/DiscordFeed/discordfeed.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import { FC } from "react";
+import { FC, Key } from "react";
 import useSWR from "swr";
 import { parse } from "discord-markdown-parser";
 import { SingleASTNode } from "simple-markdown";
@@ -222,7 +222,7 @@ export const GenerateMessageHTML: FC<{
     let content = node.content;
 
     if (Array.isArray(node.content)) {
-        content = node.content.map((value, index) => (
+        content = node.content.map((value: any, index: Key | null | undefined) => (
             <GenerateMessageHTML
                 key={index}
                 node={value} userData={userData} roleData={roleData} channelData={channelData}                
@@ -265,7 +265,7 @@ export const GenerateMessageHTML: FC<{
         case "autolink":
             return <>unimplemented markdown: autolink</>;
         case "url":
-            content = node.content.map((value, index) => {
+            content = node.content.map((value: { content: string; }, index: Key | null | undefined) => {
 
                 // Tenor is ***not*** supported right now, due to complexity in their service.
                 // Unfortunatly that disqualifies most of the Discord GIF selector.

--- a/src/components/DiscordFeed/discordfeed.tsx
+++ b/src/components/DiscordFeed/discordfeed.tsx
@@ -280,18 +280,26 @@ export const GenerateMessageHTML: FC<{
                 }
 
                 if (/\.(jpg|jpeg|png|webp|avif|gif|svg)$/.test(value.content.replace(/\?.*/, ''))) {
-                    return <GenerateAttachmentHTML
-                        attachmentId={"0"}
-                        attachmentData={[
-                            JSON.parse(`{ "id": "0", "name": "Linked Image", "link": "${value.content}", "type": "image/*"}`)
-                        ]}
-                    />
+                    return (
+                        <span>
+                            <CameraOutlined />
+                            <a className={`text-sky-500 px-[4px]`}>{value.content.replace(/[^/]*\/\/(?:[^@]*@)?([^:/]+(?:\.[^:/]+)*).*/, '$1')}</a>
+                            <br />
+                            <GenerateAttachmentHTML
+                                attachmentId={"0"}
+                                attachmentData={[
+                                    JSON.parse(`{ "id": "0", "name": "Linked Image", "link": "${value.content}", "type": "image/*"}`)
+                                ]}
+                            />
+                        </span>
+                    )
                 }
 
                 return <a className={`text-sky-500 `}>{content}</a>;
             })
 
-            return <a>{content}</a>;        case "em":
+            return <a>{content}</a>;      
+        case "em":
             return <em>{content}</em>;
         case "strong":
             return <strong>{content}</strong>;

--- a/src/components/DiscordFeed/discordfeed.tsx
+++ b/src/components/DiscordFeed/discordfeed.tsx
@@ -113,7 +113,7 @@ export const DiscordMessage: FC<{
                 <div className={`inline-block ml-4 align-middle`}>
                     <span className={`text-neutral-400 text-xl`}>
                         #{message.channel}
-                        <br />
+                        &ensp;
                         {message.time}
                     </span>
                 </div>

--- a/src/components/DiscordFeed/discordfeed.tsx
+++ b/src/components/DiscordFeed/discordfeed.tsx
@@ -73,9 +73,9 @@ export const DiscordFeed: FC = () => {
 
 export const DiscordMessage: FC<{
     message: Message;
-    userData: IdNameColour[];
-    roleData: IdNameColour[];
-    channelData: IdNameColour[];
+    userData: IdNameColor[];
+    roleData: IdNameColor[];
+    channelData: IdNameColor[];
     attachmentData: AttachmentData[];
 }> = ({
     message,

--- a/src/pages/api/fetch-attachments.ts
+++ b/src/pages/api/fetch-attachments.ts
@@ -1,0 +1,17 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { createClient } from '@vercel/postgres';
+
+const fetchAttachments = async (req: NextApiRequest, res: NextApiResponse) => {
+    const client = createClient({
+        connectionString: process.env.POSTGRES_URL_NON_POOLING
+    })
+    await client.connect();
+
+    const { rows } = await client.sql`select * from attachments;`
+
+    res.json(rows);
+
+    await client.end();
+};
+
+export default fetchAttachments;


### PR DESCRIPTION
Add support for attachments to the dashboard's Discord feed

Requires the following database changes:
- extend the messages table to include a list of attachment ids on a message
- add a table to keep a list of attachments
I will make the above changes once given a go ahead or if this is merged

Notes:
- Links to images and actual attachments appear on different lines
- Attachments are prefixed with a camera icon (Rendered Images) or a paper clip icon (Other attachments)
- If an attachment has a mime type starting with "image/", it will attempt to be rendered
- If a linked image/gif ends in any of the following (jpg, jpeg, png, webp, avif, gif, svg), it will attempt to be rendered
- Tenor gifs will be replaced with the paperclip icon and the text "Tenor-GIF" due to their convoluted system
- All attachments are links to Discord's Media CDN. This means no hosting is done locally, but images might expire after some time. This shouldn't come up realistically.

![image](https://github.com/user-attachments/assets/e397613b-bf15-4ab6-b8ef-2dbdde4fd633)
![{B5DC9401-8256-469B-B741-1D12F3434415}](https://github.com/user-attachments/assets/f621506d-9086-4c3a-a5aa-7817d09d3b83)
