### PR TITLE
fix: only create WebSocket on component mount

### DIFF
--- a/src/components/Doorbell/doorbellContext.tsx
+++ b/src/components/Doorbell/doorbellContext.tsx
@@ -48,6 +48,10 @@ export const DoorbellProvider: FC<PropsWithChildren<{}>> = ({ children }) => {
         ws.current.onerror = () => {
             setConnectionState(ConnectionState.Error);
         };
+
+		return () => {
+			ws.current?.close();
+		};
     }, []);
 
     useEffect(() => {

--- a/src/components/Doorbell/doorbellContext.tsx
+++ b/src/components/Doorbell/doorbellContext.tsx
@@ -48,7 +48,7 @@ export const DoorbellProvider: FC<PropsWithChildren<{}>> = ({ children }) => {
         ws.current.onerror = () => {
             setConnectionState(ConnectionState.Error);
         };
-    });
+    }, []);
 
     useEffect(() => {
         if (!ws.current) return;


### PR DESCRIPTION
With no dependencies, this `useEffect()` hook was creating a new WebSocket connection on every re-render of the page, which led to unbounded growth as the dashboard is open all Hack Night. Changing this to only create the WebSocket on component mount should fix the issue. The connection will reconnect automatically if disconnected because of the `reconnecting-websocket` library.

This needs more testing before being merged. There appears to be some issue with the doorbell API, so I would like to look into that before finalizing this.